### PR TITLE
Fix bug when reading sequence names without whitespace, adding tests

### DIFF
--- a/docs/source/drawbacks.rst
+++ b/docs/source/drawbacks.rst
@@ -11,7 +11,7 @@ If you intensively check sequence names exists in FASTA file using ``in`` operat
 	>>>     if seqname in fa:
 	>>>	        do something
 
-This will take a long time to finish. Becuase, pyfastx does not load the index into memory, the ``in`` operating is corresponding to sql query existence from index database. The faster alternative way to do this is:
+This will take a long time to finish. Because, pyfastx does not load the index into memory, the ``in`` operating is corresponding to sql query existence from index database. The faster alternative way to do this is:
 
 .. code:: python
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -14,7 +14,7 @@ Read plain or gzipped FASTA file and build index, support for random access to F
 	<Fasta> test/data/test.fa.gz contains 211 seqs
 
 .. note::
-	Building index may take some times. The time required to build index depends on the size of FASTA file. If index built, you can randomly access to any sequences in FASTA file. The index file can be reused to save time when you read sequences from FASTA file next time.
+	Building index may take some time. The time required to build index depends on the size of FASTA file. If index built, you can randomly access to any sequences in FASTA file. The index file can be reused to save time when you read sequences from FASTA file next time.
 
 FASTA records iteration
 -----------------------
@@ -168,7 +168,7 @@ Get counts of sequences whose length >= specified length
 Get subsequences
 ----------------
 
-Subseuqneces can be retrieved from FASTA file by using a list of [start, end] coordinates
+Subsequences can be retrieved from FASTA file by using a list of [start, end] coordinates
 
 .. code:: python
 
@@ -191,7 +191,10 @@ Key function
 
 New in ``pyfastx`` 0.5.1
 
-Sometimes your fasta will have a long header which contains multiple identifiers and description, for example, ">JZ822577.1 contig1 cDNA library of flower petals in tree peony by suppression subtractive hybridization Paeonia suffruticosa cDNA, mRNA sequence". In this case, both "JZ822577.1" and "contig1" can be used as identifer. you can specify the key function to select one as identifier.
+Sometimes your fasta will have a long header which contains multiple identifiers and description, for example,
+">JZ822577.1 contig1 cDNA library of flower petals in tree peony by suppression subtractive hybridization Paeonia suffruticosa cDNA, mRNA sequence".
+In this case, either "JZ822577.1" or "contig1" could be used as the identifier.
+You can specify the key function to select one as identifier.
 
 .. code:: python
 
@@ -357,17 +360,17 @@ Search for subsequence from given sequence and get one-based start position of t
 
 .. code:: python
 
-    >>> # search subsequence in sense strand
-    >>> fa[0].search('GCTTCAATACA')
-    262
+	>>> # search subsequence in sense strand
+	>>> fa[0].search('GCTTCAATACA')
+	262
 
-    >>> # check subsequence weather in sequence
-    >>> 'GCTTCAATACA' in fa[0]
-    True
+	>>> # check subsequence weather in sequence
+	>>> 'GCTTCAATACA' in fa[0]
+	True
 
-    >>> # search subsequence in antisense strand
-    >>> fa[0].search('CCTCAAGT', '-')
-    301
+	>>> # search subsequence in antisense strand
+	>>> fa[0].search('CCTCAAGT', '-')
+	301
 
 FASTQ
 =====

--- a/src/index.c
+++ b/src/index.c
@@ -80,7 +80,7 @@ PyObject* pyfastx_get_next_seq(pyfastx_Index *self){
 			upper_string(self->kseqs->seq.s, self->kseqs->seq.l);
 		}
 
-		if (self->full_name) {
+		if (self->full_name && self->kseqs->comment.s) {
 			PyObject *fname = PyUnicode_FromFormat("%s %s", self->kseqs->name.s, self->kseqs->comment.s);
 			PyObject *ret = Py_BuildValue("(Os)", fname, self->kseqs->seq.s);
 			Py_DECREF(fname);

--- a/tests/test_fasta.py
+++ b/tests/test_fasta.py
@@ -3,11 +3,13 @@ import random
 import pyfastx
 import pyfaidx
 import unittest
+from .testing_utils import get_test_data
 
-gzip_fasta = 'tests/data/test.fa.gz'
-flat_fasta = 'tests/data/test.fa'
-rna_fasta = 'tests/data/rna.fa'
-protein_fasta = 'tests/data/protein.fa'
+gzip_fasta = get_test_data('test.fa.gz')
+flat_fasta = get_test_data('test.fa')
+rna_fasta = get_test_data('rna.fa')
+protein_fasta = get_test_data('protein.fa')
+
 
 class FastaTest(unittest.TestCase):
 	def setUp(self):
@@ -141,6 +143,18 @@ class FastaTest(unittest.TestCase):
 			expect = str(self.faidx[name])
 			self.assertEqual(expect, seq)
 
+	def test_iter_full_name(self):
+		fa = pyfastx.Fasta(rna_fasta, build_index=False, full_name=True)
+
+		for name, seq in fa:
+			self.assertTrue(name in {"LOC_Os10g33000", "LOC_Os02g06840"})
+
+	def test_key_func(self):
+		fa = pyfastx.Fasta(gzip_fasta, build_index=True, key_func=lambda x: x.split()[1])
+
+		for seq in fa:  # type: pyfastx.Sequence
+			self.assertTrue(seq.name.startswith("contig"))
+
 	def test_statistics(self):
 		lens = sorted([len(seq) for seq in self.faidx], reverse=True)
 		half = sum(lens)/2
@@ -229,6 +243,7 @@ class FastaTest(unittest.TestCase):
 
 		with self.assertRaises(ValueError):
 			self.fastx.nl(101)
+
 
 if __name__ == '__main__':
 	unittest.main()

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1,0 +1,13 @@
+import os
+from pkg_resources import Requirement, resource_filename, ResolutionError
+
+
+def get_test_data(filename):
+    filepath = None
+    try:
+        filepath = resource_filename(Requirement.parse("pyfastx"), "tests/data/" + filename)
+    except ResolutionError:
+        pass
+    if not filepath or not os.path.isfile(filepath):
+        filepath = os.path.join(os.path.dirname(__file__), 'data', filename)
+    return filepath


### PR DESCRIPTION
Thanks for writing such great software, Lianming! I really appreciate it.

I've attempted to fix that bug I reported and wrote a test to catch it. Some edits to the documentation are also included.

While mucking around with pyfastx I also noticed that the `key_func` feature may not be working as expected, but I may be mis-interpreting how it works exactly. Anyway, I wrote a test for `key_func` that checks whether the new identifiers (presumably stored as the 'name' attribute?) match a specific prefix ('contig') when parsing the FASTA file `test.fa`. This test is currently failing because it appears to me that no Sequence attributes are modified according to `key_func`.

Lastly, I included a few functions in `tests/testing_utils.py` to make retrieving test data more straightforward.

Thanks again!

