### PR TITLE
Reset statements after failed fetches by id/name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -990,9 +990,11 @@ This will take a long time to finish. Becuase, pyfastx does not load the index i
 Testing
 =======
 
-The ``pyfaidx`` module was used to test ``pyfastx``. To run the tests:
+The ``pyfaidx`` module was used to test ``pyfastx``. First, make sure you have a suitable version installed::
 
-::
+    pip install '.[dev]'
+
+Then, to run the tests::
 
 	$ python setup.py test
 

--- a/setup.py
+++ b/setup.py
@@ -85,5 +85,13 @@ setup(
         'console_scripts': ['pyfastx = pyfastxcli:main']
     },
     py_modules = ["pyfastxcli"],
-    test_suite = "tests"
+    test_suite = "tests",
+    extras_requires = {
+        "dev": [
+            # pyfaidx is used as ground truth for expected values.  Version
+            # 0.5.9 and newer don't support negative indexes, which are used in
+            # our tests.
+            "pyfaidx <=0.5.8",
+        ],
+    }
 )

--- a/src/index.c
+++ b/src/index.c
@@ -534,6 +534,7 @@ PyObject *pyfastx_index_get_seq_by_name(pyfastx_Index *self, PyObject *sname){
 		);
 		return (PyObject *)obj;
 	} else {
+		PYFASTX_SQLITE_CALL(sqlite3_reset(self->seq_stmt));
 		PyErr_Format(PyExc_KeyError, "%s does not exist in fasta file", name);
 		return NULL;
 	}
@@ -568,6 +569,7 @@ PyObject *pyfastx_index_get_seq_by_id(pyfastx_Index *self, uint32_t chrom){
 		);
 		return (PyObject *)obj;
 	} else { 
+		PYFASTX_SQLITE_CALL(sqlite3_reset(self->uid_stmt));
 		PyErr_SetString(PyExc_IndexError, "Index Error");
 		return NULL;
 	}

--- a/tests/test_sequence_error.py
+++ b/tests/test_sequence_error.py
@@ -1,0 +1,81 @@
+import os
+import random
+import pyfastx
+import pyfaidx
+import unittest
+
+join = os.path.join
+data_dir = join(os.path.dirname(__file__), 'data')
+
+flat_fasta = join(data_dir, 'test.fa')
+
+class SequenceErrorTest(unittest.TestCase):
+	def setUp(self):
+		self.fastx = pyfastx.Fasta(flat_fasta)
+
+		self.faidx = pyfaidx.Fasta(flat_fasta, sequence_always_upper=True)
+
+		self.count = len(self.fastx)
+
+	def tearDown(self):
+		del self.fastx
+		del self.faidx
+
+		if os.path.exists('{}.fxi'.format(flat_fasta)):
+			os.remove('{}.fxi'.format(flat_fasta))
+
+		if os.path.exists('{}.fai'.format(flat_fasta)):
+			os.remove('{}.fai'.format(flat_fasta))
+
+	def get_random_index(self):
+		return random.randint(0, self.count-1)
+
+	def get_random_key(self):
+		idx = self.get_random_index()
+		return list(self.faidx.keys())[idx]
+
+	def test_seq_by_index(self):
+		# get valid index
+		idx = self.get_random_index()
+
+		expect = self.faidx[idx][:]
+		result = self.fastx[idx]
+
+		self.assertEqual(expect.name, result.name)
+		self.assertEqual(expect.seq, result.seq)
+
+		# get invalid index
+		with self.assertRaises(IndexError):
+		    self.fastx[self.count + 100]
+
+		# get valid index again
+		expect = self.faidx[idx][:]
+		result = self.fastx[idx]
+
+		self.assertEqual(expect.name, result.name)
+		self.assertEqual(expect.seq, result.seq)
+
+	def test_seq_by_key(self):
+		# get valid key
+		key = self.get_random_key()
+
+		expect = self.faidx[key][:]
+		result = self.fastx[key]
+
+		self.assertEqual(expect.name, result.name)
+		self.assertEqual(expect.seq, result.seq)
+
+		# get invalid key
+		with self.assertRaises(KeyError):
+		    self.fastx['__BOGUS_KEY_FOR_TESTING__']
+
+		# get valid key again
+		expect = self.faidx[key][:]
+		result = self.fastx[key]
+
+		self.assertEqual(expect.name, result.name)
+		self.assertEqual(expect.seq, result.seq)
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
Otherwise the index is unusable after the first IndexError/KeyError, as it keeps returning the same error result even for valid keys.

Failing tests are added in one commit, then the bug is fixed and those tests pass.

Resolves: https://github.com/lmdu/pyfastx/issues/50