### PR TITLE
src/index.c: fix typo caught by linting.

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -155,7 +155,7 @@ void pyfastx_create_index(pyfastx_Index *self){
 			boff INTEGER, --seq offset start\n \
 			blen INTEGER, --seq byte length\n \
 			slen INTEGER, --seq length\n \
-			llen INTEGER, --line lenght\n \
+			llen INTEGER, --line length\n \
 			elen INTEGER, --end length\n \
 			norm INTEGER, --line with the same length or not\n \
 			dlen INTEGER --description header line length\n \


### PR DESCRIPTION
Hi,

While working on the packaging of pyfastx, lintian caught a typo which you may like to see fixed.

Have a nice day,  :)
Étienne.