### PR TITLE
performance update kseq 

### DIFF
--- a/src/kseq.c
+++ b/src/kseq.c
@@ -73,8 +73,8 @@ Py_ssize_t ks_getuntil2(kstream_t *ks, int delimiter, kstring_t *str, int *dret,
 			} else break;											
 		}															
 		if (delimiter == KS_SEP_LINE) { 
-			for (i = ks->begin; i < ks->end; ++i) 
-				if (ks->buf[i] == '\n') break; 
+			unsigned char *sep = (unsigned char*)memchr(ks->buf + ks->begin, '\n', ks->end - ks->begin);
+			i = sep != NULL ? sep - ks->buf : ks->end;
 		} else if (delimiter > KS_SEP_MAX) {						
 			for (i = ks->begin; i < ks->end; ++i)					
 				if (ks->buf[i] == delimiter) break;					

--- a/src/kseq.h
+++ b/src/kseq.h
@@ -10,7 +10,6 @@
 #define KS_SEP_TAB   1 // isspace() && !' '
 #define KS_SEP_LINE  2 // line separator: "\n" (Unix) or "\r\n" (Windows)
 #define KS_SEP_MAX   2
-
 #define BUF_SIZE     1048576
 
 #define ks_err(ks) ((ks)->end == -1)


### PR DESCRIPTION
as in [https://github.com/lh3/seqtk/pull/123](https://github.com/lmdu/pyfastx/commit/f746aa050aa7abd31d6d021270064a1b2ae86904)

Tested on fasta files speedup from 3.887 s ±  0.099 s  to 3.408 s ±  0.119 s  