### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -214,7 +214,7 @@ Get FASTA information
 
     >>> # get GC skew of DNA sequences in FASTA
     >>> # New in pyfastx 0.3.8
-    >>> fa.gc_skews
+    >>> fa.gc_skew
     0.004287730902433395
 
     >>> # get composition of nucleotides in FASTA


### PR DESCRIPTION
Found in version 2.1.0

The docs specify `fa.gc_skews` but the library uses `fa.gc_skew`. Changed readme to match