### PR TITLE
Fix int32 truncation of seq byte length (blen): segfault on sequences > 2 GB

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -240,7 +240,7 @@ void pyfastx_create_index(pyfastx_Index *self){
 					sqlite3_bind_null(stmt, 1);
 					sqlite3_bind_text(stmt, 2, chrom.s, chrom.l, SQLITE_STATIC);
 					sqlite3_bind_int64(stmt, 3, start);
-					sqlite3_bind_int(stmt, 4, position-start-line.l-1);
+					sqlite3_bind_int64(stmt, 4, position-start-line.l-1);
 					sqlite3_bind_int64(stmt, 5, seq_len);
 					sqlite3_bind_int64(stmt, 6, line_len);
 					sqlite3_bind_int(stmt, 7, line_end);
@@ -345,7 +345,7 @@ void pyfastx_create_index(pyfastx_Index *self){
 		sqlite3_bind_null(stmt, 1);
 		sqlite3_bind_text(stmt, 2, chrom.s, chrom.l, SQLITE_STATIC);
 		sqlite3_bind_int64(stmt, 3, start);
-		sqlite3_bind_int(stmt, 4, position-start);
+		sqlite3_bind_int64(stmt, 4, position-start);
 		sqlite3_bind_int64(stmt, 5, seq_len);
 		sqlite3_bind_int64(stmt, 6, line_len);
 		sqlite3_bind_int(stmt, 7, line_end);


### PR DESCRIPTION
## Problem

`pyfastx_create_index` binds the per-record byte length (`blen`, column 4 of the `seq` table) with `sqlite3_bind_int` (32-bit) at **both** INSERT sites, while every other large column — `boff`, `slen`, `llen` — uses `sqlite3_bind_int64`. The value `position - start - line.l - 1` is computed correctly in 64-bit (`position` and `start` are `Py_ssize_t`), but the 32-bit bind truncates it.

So for any sequence whose **on-disk byte length** (bases + newlines) exceeds 2³¹ (≈ 2.147 GB) — e.g. the ~2.1 Gbp chromosomes of large genomes such as the South American lungfish (`GCA_964263255.1`) — `blen` is stored **negative**. The read path reads `blen` back via `sqlite3_column_int64`, so the corrupt (negative) value becomes a bogus `malloc`/`fread` size → **segfault on any access to that sequence**, including a small `fetch`.

## Reproduction

```python
import pyfastx
fa = pyfastx.Fasta('GCA_964263255.1.fa')
fa['OZ183349.1'].seq      # 2,144,885,605 bp -> SIGSEGV
```

In the `.fxi`:

```sql
SELECT chrom, slen, blen FROM seq WHERE blen < 0;
-- returns the >2^31-byte records, each with a negative blen
```

The true value equals `stored_blen + 2^32`, verified byte-exact against `next.boff - this.boff - header_len`.

## Fix

Bind `blen` with `sqlite3_bind_int64` at both INSERT sites (the per-record loop and the final/EOF record), matching `boff`/`slen`/`llen`.

`elen`, `norm`, `dlen` keep `sqlite3_bind_int` — they are small by construction. The FASTQ `read` table already binds its lengths/offsets (`rlen`/`soff`/`qoff`) with `_int64`, so it is unaffected.

## Note on existing indexes

`.fxi` files built before this fix remain corrupt and must be rebuilt, or patched in place:

```sql
UPDATE seq SET blen = blen + 4294967296 WHERE blen < 0;
```
